### PR TITLE
[JENKINS-20935] - Added a monitoring page, which provides links to JavaMelody actions

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/NodeMonitoringAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/NodeMonitoringAction.java
@@ -21,6 +21,7 @@ package org.jvnet.hudson.plugins.monitoring;
 import hudson.model.Action;
 import hudson.model.Computer;
 import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 
 /**
  * Implements a "Monitoring" button for slaves.
@@ -32,22 +33,24 @@ public class NodeMonitoringAction implements Action {
 	private final Computer computer;
 	private final String displayName;
 	private final String iconPath;
-	private String url;
 
 	/**
-	 * Constructeur.
+	 * Constructor.
 	 * @param computer Computer
 	 * @param displayName String
 	 * @param iconPath String
 	 * @param url String
 	 */
-	public NodeMonitoringAction(Computer computer, String displayName, String iconPath, String url) {
+	public NodeMonitoringAction(Computer computer, String displayName, String iconPath) {
 		super();
 		this.computer = computer;
 		this.displayName = displayName;
 		this.iconPath = iconPath;
-		this.url = url;
 	}
+
+        public Computer getComputer() {
+                return computer;
+        }
 
 	/** {@inheritDoc} */
 	@Override
@@ -64,16 +67,15 @@ public class NodeMonitoringAction implements Action {
 	/** {@inheritDoc} */
 	@Override
 	public String getUrlName() {
-		return url;
+		return "monitoring";
 	}
-
-	/**
-	 * Sets urlName.
-	 * @param url String
-	 */
-	public void setUrlName(String url) {
-		this.url = url;
-	}
+        
+        public String getMonitoringUrl() {
+                String urlSuffix = (computer instanceof Jenkins.MasterComputer)
+                        ? ""
+                        : "/nodes/"+computer.getName();
+                return "/"+getUrlName() + urlSuffix;
+        }
 
 	/**
 	 * Checks that user has access permissions to the monitoring page.

--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesMonitoringActionFactory.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesMonitoringActionFactory.java
@@ -27,37 +27,20 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import jenkins.model.Jenkins;
-
 /**
  * Generates a {@link NodeMonitoringAction} for the each slave computer.
  * @author Oleg Nenashev <o.v.nenashev@gmail.com>, Emeric Vernat
  */
 @Extension
 public class NodesMonitoringActionFactory extends TransientComputerActionFactory {
-
+        public static final String ICON_FILE = "monitor.gif";
+    
 	/** {@inheritDoc} */
 	@Override
 	public Collection<? extends Action> createFor(Computer computer) {
-		final List<NodeMonitoringAction> result = new ArrayList<NodeMonitoringAction>();
-		result.add(new NodeMonitoringAction(computer, "View threads",
-				"../../../../monitoring?resource=threads.png", "../../monitoring?part=threads"));
-		result.add(new NodeMonitoringAction(computer, "Execute the garbage collector",
-				"../../../../monitoring?resource=broom.png", "../../monitoring?action=gc"));
-		result.add(new NodeMonitoringAction(computer, "Generate a heap dump",
-				"../../../../monitoring?resource=heapdump.png", "../../monitoring?action=heap_dump"));
-		result.add(new NodeMonitoringAction(computer, "View memory histogram",
-				"../../../../monitoring?resource=memory.png", "../../monitoring?part=heaphisto"));
-		result.add(new NodeMonitoringAction(computer, "MBeans",
-				"../../../../monitoring?resource=mbeans.png", "../../monitoring?part=mbeans"));
-		result.add(new NodeMonitoringAction(computer, "View OS processes",
-				"../../../../monitoring?resource=processes.png", "../../monitoring?part=processes"));
-		if (!(computer instanceof Jenkins.MasterComputer)) {
-			for (final NodeMonitoringAction action : result) {
-				action.setUrlName(action.getUrlName().replace("/monitoring",
-						"/monitoring/nodes/" + computer.getName()));
-			}
-		}
-		return result;
+            final List<NodeMonitoringAction> result = new ArrayList<NodeMonitoringAction>();
+            // Add a single monitoring action, which will handle all monitoring features
+            result.add(new NodeMonitoringAction(computer, "Monitoring", ICON_FILE));
+            return result;
 	}
 }

--- a/src/main/resources/org/jvnet/hudson/plugins/monitoring/NodeMonitoringAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/monitoring/NodeMonitoringAction/index.jelly
@@ -1,0 +1,99 @@
+<!--
+* The MIT License
+*
+* Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <l:layout permission="${app.ADMINISTER}" xmlns:local="local" norefresh="true">
+        <st:include it="${app}" page="sidepanel.jelly"/>
+        <l:main-panel>
+            <h1>
+                <img src="${imagesURL}/48x48/${it.iconFileName}" alt="${it.displayName}"/>
+                ${%JavaMelody Monitoring}
+            </h1>
+            <p>This page provides access to the integrated <a href="http://code.google.com/p/javamelody/">JavaMelody</a> monitoring of the
+                <a href="${rootUrl}/${it.computer.url}">${it.computer.displayName}</a> node.
+            </p>
+            
+            <d:taglib uri="local">
+                <!-- table to show a map -->
+                <d:tag name="feature">
+                    <t:summary icon="${icon}"
+                           href="${href}" iconOnly="true">
+                        <div class="link">
+                            <a href="${href}">${title}</a>
+                        </div>
+                        <div style="color:gray; text-decoration:none;">
+                            <d:invokeBody />
+                        </div>
+                    </t:summary>
+                </d:tag>
+            </d:taglib>
+
+            <table style="padding-left: 2em;" id="management-links">
+                <local:feature icon="monitor.gif" 
+                             href="${it.monitoringUrl}" 
+                             title="${%JavaMelody}">
+                    ${%Open the main page}
+                </local:feature>
+            </table>
+            <h2>${%Particular data monitors}</h2>
+            <table style="padding-left: 2em;" id="management-links">
+                <local:feature icon="${rootUrl}/monitoring?resource=threads.png" 
+                             href="${it.monitoringUrl}?part=threads" 
+                             title="${%View Threads}">
+                    ${%View threads on the node}
+                </local:feature>
+                <local:feature icon="${rootUrl}/monitoring?resource=processes.png" 
+                             href="${it.monitoringUrl}?part=processes" 
+                             title="${%OS Processes}">
+                    ${%View OS processes}
+                </local:feature>
+                <local:feature icon="${rootUrl}/monitoring?resource=memory.png" 
+                             href="${it.monitoringUrl}?part=heaphisto" 
+                             title="${%Memory histogram}">
+                    ${%View memory usage histogram.} <b>${%JDK is required}</b>
+                </local:feature>
+                <local:feature icon="${rootUrl}/monitoring?resource=mbeans.png" 
+                             href="${it.monitoringUrl}?part=mbeans" 
+                             title="${%MBeans}">
+                    ${%Display data collected by MBeans}
+                </local:feature>
+            </table>
+              
+            <h2>${%Management actions}</h2>
+            <table style="padding-left: 2em;" id="management-actions">
+                <local:feature icon="${rootUrl}/monitoring?resource=broom.png" 
+                               href="${it.monitoringUrl}?action=gc" 
+                               title="${%Execute the garbage collector}">
+                    ${%Runs gargbage collection on the node}
+                </local:feature>
+                <local:feature icon="${rootUrl}/monitoring?resource=heapdump.png" 
+                             href="${it.monitoringUrl}?action=heap_dump" 
+                             title="${%Generate a heap dump}">
+                    <b style="color:red">${%Warning!}</b> ${%This operation may affect performance of the node}
+                </local:feature>
+            </table>
+        </l:main-panel>
+    </l:layout>
+         
+</j:jelly>


### PR DESCRIPTION
This implementation reduces number of management actions on node dashboards.

Improves https://issues.jenkins-ci.org/browse/JENKINS-20935

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com

![newmonitoringlayout](https://f.cloud.github.com/assets/3000480/1844768/64003a10-7551-11e3-829d-10626912b8e4.png)
