### PR TITLE
[JENKINS-34794] Jenkins doesn't start because of NPE

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesListener.java
@@ -77,7 +77,12 @@ public class NodesListener extends ComputerListener {
 			final Jenkins jenkins = Jenkins.getInstance();
 			if (jenkins != null) {
 				final PluginImpl pluginImpl = jenkins.getPlugin(PluginImpl.class);
-				nodesCollector = pluginImpl.getFilter().getNodesCollector();
+				if (pluginImpl != null) {
+					HudsonMonitoringFilter hMonitoringFilter = pluginImpl.getFilter();
+					if (hMonitoringFilter != null) {
+						nodesCollector = hMonitoringFilter.getNodesCollector();
+					}
+				}
 			}
 		}
 		return nodesCollector;

--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesListener.java
@@ -50,7 +50,10 @@ public class NodesListener extends ComputerListener {
 	public void onOnline(Computer c, TaskListener listener)
 			throws IOException, InterruptedException {
 		try {
-			getNodesCollector().scheduleCollectNow();
+			NodesCollector nodesCollector = getNodesCollector();
+			if (nodesCollector != null) {
+				nodesCollector.scheduleCollectNow();
+			}
 		} catch (final IllegalStateException e) {
 			// if timer already canceled, do nothing
 			// [JENKINS-17757] IllegalStateException: Timer already cancelled from NodesCollector.scheduleCollectNow


### PR DESCRIPTION
```
hudson.util.HudsonFailedToLoad: java.lang.NullPointerException
at hudson.WebAppMain$3.run(WebAppMain.java:237)

Caused by: java.lang.NullPointerException
at org.jvnet.hudson.plugins.monitoring.NodesListener.getNodesCollector(NodesListener.java:77)
at org.jvnet.hudson.plugins.monitoring.NodesListener.onOnline(NodesListener.java:53)
at jenkins.model.Jenkins.<init>(Jenkins.java:850)
at hudson.model.Hudson.<init>(Hudson.java:83)
at hudson.model.Hudson.<init>(Hudson.java:79)
at hudson.WebAppMain$3.run(WebAppMain.java:225)
```

@reviewbybees