### PR TITLE
Avoid implied deps with jenkins min. v2.190.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 	<properties>
 		<jenkins.version>2.190.1</jenkins.version>
 		<java.level>8</java.level>
+		<slf4jVersion>1.7.26</slf4jVersion>
 	</properties>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.50</version>
+		<version>3.57</version>
 		<relativePath />
 	</parent>
 	<groupId>org.jvnet.hudson.plugins</groupId>
@@ -19,7 +19,7 @@
 	<inceptionYear>2009</inceptionYear>
 
 	<properties>
-		<jenkins.version>2.60.3</jenkins.version>
+		<jenkins.version>2.190.1</jenkins.version>
 		<java.level>8</java.level>
 	</properties>
 


### PR DESCRIPTION
With a minimum Jenkins version of 2.190.1 the following implied plugin dependencies are avoided:
* Command Agent Launcher v.1.0
* Oracle Java SE Development Kit Installer v.1.0
* JAXB v.2.3.0
* Trilead API v.1.0.4