### PR TITLE
Use "Jenkins instance" instead of "Jenkins master"

### DIFF
--- a/docs/MonitoringScripts.md
+++ b/docs/MonitoringScripts.md
@@ -11,13 +11,13 @@ arbitrary scripts on the Jenkins server (or on slave nodes). This
 feature can be accessed from the "manage Jenkins" link, typically at
 your <http://server/jenkins/script>. See [more information and scripts](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console).
 
-# Monitoring Scripts and Alerts for Jenkins master
+# Monitoring Scripts and Alerts for the Jenkins instance
 
 If the [Monitoring plugin](https://plugins.jenkins.io/monitoring) is installed, you can also use the following
 monitoring scripts in the **Jenkins script console**. To run a script
 periodically, you could also create and schedule a job to execute a
 **system groovy script** with the [groovy plugin](https://wiki.jenkins.io/display/JENKINS/Groovy+plugin). (A system Groovy script
-executes insides Jenkins master's JVM, but see below for specific
+executes insides Jenkins instance's JVM, but see below for specific
 scripts for Jenkins slaves.)
 
 The data printed by the scripts below can be displayed by the reports of
@@ -194,7 +194,7 @@ for (request in aggreg.getRequests()) {
 
 You can send alerts with a Jenkins job, using a **system groovy script** with the [groovy plugin](https://plugins.jenkins.io/groovy).
 
-Suppose that you want to check every 15 minutes on the Jenkins master, if the system load average is above 50 or if the active HTTP threads
+Suppose that you want to check every 15 minutes on the Jenkins instance, if the system load average is above 50 or if the active HTTP threads
 count is above 100 or if there are deadlocked threads or if there are less than 10 Gb free disk space left:
 
 * Create a freestyle job in Jenkins by clicking "New item".

--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesManagementLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/NodesManagementLink.java
@@ -26,7 +26,7 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
 /**
- * {@link ManagementLink} of the plugin to add a link in the "/manage" page, for the agents next to the one for the master.
+ * {@link ManagementLink} of the plugin to add a link in the "/manage" page, for the agents next to the one for the instance.
  * @author Emeric Vernat
  */
 @Extension(ordinal = Integer.MAX_VALUE - 491)

--- a/src/main/java/org/jvnet/hudson/plugins/monitoring/PluginManagementLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/monitoring/PluginManagementLink.java
@@ -53,7 +53,7 @@ public class PluginManagementLink extends ManagementLink {
 	 */
 	@Override
 	public String getDescription() {
-		return "Monitoring of memory, cpu, http requests and more in Jenkins master.";
+		return "Monitoring of memory, cpu, http requests and more in the Jenkins instance.";
 	}
 
 	/**
@@ -63,7 +63,7 @@ public class PluginManagementLink extends ManagementLink {
 	 */
 	@Override
 	public String getDisplayName() {
-		return "Monitoring of Jenkins master";
+		return "Monitoring of Jenkins instance";
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
Replacing the management link's text "Monitoring of the Jenkins master" by "Monitoring of the Jenkins instance" and some other wording here and there.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
