### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'linux', jdk: 25],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<revision>2.7.0</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<jenkins.version>2.479.1</jenkins.version>
+		<jenkins.version>2.479.3</jenkins.version>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 		<ban-junit4-imports.skip>false</ban-junit4-imports.skip>
 	</properties>


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  Jenkins core (weekly) has supported Java 25 since Jenkins 2.534, Oct 28, 2025.  Jenkins core (LTS) has supported Java 25 since 2.541.1, Jan 21, 2026.  90% of the 250 most popular plugin repositories now compile and test with Java 25.

Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

Does not compile or test with Java 17. We have found no issues in the past that were specific to the Java 17 compiler.  Java 17 support has been dropped from Jenkins weekly and will be dropped from Jenkins LTS in April 2026.

Pull request includes other changes necessary to support Java 25:

* Require Jenkins 2.479.3 or newer (fix compile on master branch)

### Testing done

* Confirmed that automated tests pass with Java 25 on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
